### PR TITLE
feat: add Exo Experts warbond icons

### DIFF
--- a/Exo Experts/Breakthrough Exosuit.svg
+++ b/Exo Experts/Breakthrough Exosuit.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+  <desc>Traced by Dogo314</desc>
+  <g transform="translate(-276 -306)">
+    <path style="fill:none" d="M276 306h256v256H276z"/>
+    <clipPath id="a">
+      <path d="M276 306h256v256H276z"/>
+    </clipPath>
+    <g clip-path="url(#a)">
+      <path d="M688 1930h-16l-12-12v-24h-24v-28l8-8h16l8-8h24l8 8h16l8 8v28h-24v24zm4-64h-24v20h24zm-40 36v26l12 12v14l12 12h-40l12-12v-8l-12-12v-32zm56 0h16v32l-12 12v8l12 12h-40l12-12v-14l12-12z" style="fill:#53bcda" transform="translate(-276 -1440)"/>
+      <path d="M1441 1793v25h-33v-25zm13 1.823a12.6 12.6 0 0 1 4.177 4.177H1454zm5.749 8.177q.25 1.214.251 2.5-.002 1.286-.251 2.5H1454v-5zm-1.572 9a12.6 12.6 0 0 1-4.177 4.177V1812zM1445 1799v-6h2.5q.25 0 .5.01 1.024.041 2 .241V1799zm0 9v-5h5v5zm5 9.749a12.4 12.4 0 0 1-2.5.251h-2.5v-6h5zM1572 1839l-28-17v-44l28-5 28 5v44z" style="fill:#ffe" transform="translate(-1104 -1440)"/>
+    </g>
+  </g>
+</svg>

--- a/Exo Experts/Bullet Storm.svg
+++ b/Exo Experts/Bullet Storm.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+  <desc>Traced by Dogo314</desc>
+  <g transform="translate(-276 -306)">
+    <path style="fill:none" d="M276 306h256v256H276z"/>
+    <clipPath id="a">
+      <path d="M276 306h256v256H276z"/>
+    </clipPath>
+    <g clip-path="url(#a)">
+      <path d="M356 2350v20h-8v-20zm78 16-5 4h-65v-20h65l5 4h15l11 6-11 6zm-78 12v20h-8v-20zm78 16-5 4h-65v-20h65l5 4h15l11 6-11 6zm-78 12v20h-8v-20zm78 16-5 4h-65v-20h65l5 4h15l11 6-11 6z" style="fill:#ffe" transform="translate(0 -1992)"/>
+      <path d="M3714 2731.143V2727h4.833l1.167-1h69v1h11v-1h10v1h10v2h-2v28h2v2h-7v8h3v4l-2 3h-2l-3 3h-56l-5 5h-3v-5h-27s-5.501 5.785-6 6-16 0-16 0l-9.849 14.326a3 3 0 0 0-.024 3.364l.382.574c.313.469.413 1.048.276 1.594l-.406 1.627a2 2 0 0 1-1.941 1.515h-.966c-.31 0-.617-.072-.894-.211l-11.601-5.801a2 2 0 0 1-.797-2.857L3681 2780v-3a2 2 0 0 0-2-2h-33l-8 11h-13l-2-2-2 2h-6.892a2 2 0 0 1-1.997-2.105l1.789-34a2 2 0 0 1 1.997-1.895H3621l2 2 9-4h55l16.641-9.245a6 6 0 0 1 2.914-.755H3713v-4zM3666 2771v-5h-5v5zm-22 0v-5h-11l-2 2v12l1 1h1l8-10zm60 5a.997.997 0 0 0-1 1v3a1 1 0 0 0 1 1h7l1-5zm-47-5v-5h-7v5z" style="fill:#53bcda" transform="translate(-3312 -2268)"/>
+    </g>
+  </g>
+</svg>

--- a/Exo Experts/Lumberer Exosuit.svg
+++ b/Exo Experts/Lumberer Exosuit.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+  <desc>Traced by Dogo314</desc>
+  <g transform="translate(-276 -306)">
+    <path style="fill:none" d="M276 306h256v256H276z"/>
+    <clipPath id="a">
+      <path d="M276 306h256v256H276z"/>
+    </clipPath>
+    <g clip-path="url(#a)">
+      <path d="M688 1930h-16l-12-12v-24h-24v-28l8-8h16l8-8h24l8 8h16l8 8v28h-24v24zm4-64h-24v20h24zm-40 36v26l12 12v14l12 12h-40l12-12v-8l-12-12v-32zm56 0h16v32l-12 12v8l12 12h-40l12-12v-14l12-12z" style="fill:#53bcda" transform="translate(-276 -1440)"/>
+      <path d="m1756 1806-10 7h-22l-8 8h-32v-30h32l8 8h22zm84-33v21l-13 13v16l16 16v-10l-8-8 16-16v10l8 8-6 6v10l19-19-8-23-6 15v-21z" style="fill:#ffe" transform="translate(-1380 -1440)"/>
+    </g>
+  </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -598,6 +598,31 @@ Feel free to use them in your own projects !
     </tbody>
 </table>
 
+## Exo Experts
+
+<table style="min-width:300px">
+    <thead>
+        <tr>
+            <th>Icon</th>
+            <th>Name</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/nvigneux/Helldivers-2-Stratagems-icons-svg/master/Exo%20Experts/Bullet%20Storm.svg"><img width=55 src="https://raw.githubusercontent.com/nvigneux/Helldivers-2-Stratagems-icons-svg/master/Exo%20Experts/Bullet%20Storm.svg" alt="MGX-42 Bullet Storm" style="max-width: 100%;"></a></td>
+            <td>Bullet Storm</td>
+        </tr>
+        <tr>
+            <td><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/nvigneux/Helldivers-2-Stratagems-icons-svg/master/Exo%20Experts/Lumberer%20Exosuit.svg"><img width=55 src="https://raw.githubusercontent.com/nvigneux/Helldivers-2-Stratagems-icons-svg/master/Exo%20Experts/Lumberer%20Exosuit.svg" alt="EXO-51 Lumberer Exosuit" style="max-width: 100%;"></a></td>
+            <td>Lumberer Exosuit</td>
+        </tr>
+        <tr>
+            <td><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/nvigneux/Helldivers-2-Stratagems-icons-svg/master/Exo%20Experts/Breakthrough%20Exosuit.svg"><img width=55 src="https://raw.githubusercontent.com/nvigneux/Helldivers-2-Stratagems-icons-svg/master/Exo%20Experts/Breakthrough%20Exosuit.svg" alt="EXO-55 Breakthrough Exosuit" style="max-width: 100%;"></a></td>
+            <td>Breakthrough Exosuit</td>
+        </tr>
+    </tbody>
+</table>
+
 ## General Stratagems
 
 <table style="min-width:300px">


### PR DESCRIPTION
## Exo Experts Premium Warbond Icons

Adds SVG icons for the three new stratagems from the Exo Experts warbond (released April 28, 2026):

### Icons Added
- **Bullet Storm** — MGX-42 heavy machine gun support weapon
- **Lumberer Exosuit** — EXO-51 bipedal exosuit
- **Breakthrough Exosuit** — EXO-55 bipedal exosuit

SVGs sourced from helldivers.wiki.gg (traced by Dogo314), background and border stripped to match repo convention (transparent background, icon artwork only).